### PR TITLE
[#5] Close AMQP Connections.

### DIFF
--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGateway.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGateway.java
@@ -487,7 +487,7 @@ public abstract class AbstractMqttProtocolGateway extends AbstractVerticle {
         tenantConnectionManager.closeEndpoint(tenantId, endpoint)
                 .onSuccess(amqpLinkClosed -> {
                     if (amqpLinkClosed) {
-                        log.info("closing AMQP connection for tenant [{}]", tenantId);
+                        log.info("closed AMQP connection for tenant [{}]", tenantId);
                     }
                 });
     }

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
@@ -62,7 +62,7 @@ public interface MultiTenantConnectionManager {
     boolean closeEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
 
     /**
-     * Closes all connections, MQTT connections as well as AMQP for all tenants.
+     * Closes all connections, MQTT connections as well as AMQP connections for all tenants.
      */
     void closeAllTenants();
 

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.gateway.sdk.mqtt2amqp;
+
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
+import org.eclipse.hono.client.device.amqp.CommandResponder;
+import org.eclipse.hono.client.device.amqp.EventSender;
+import org.eclipse.hono.client.device.amqp.TelemetrySender;
+import org.eclipse.hono.config.ClientConfigProperties;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.mqtt.MqttEndpoint;
+
+/**
+ * Manages connections for multiple tenants.
+ */
+public interface MultiTenantConnectionManager {
+
+    /**
+     * Connect to Hono's AMQP adapter with the given configuration.
+     *
+     * @param tenantId The tenant to connect.
+     * @param vertx The Vert.x instance to use for the connection.
+     * @param clientConfig The configuration of the connection.
+     * @return a succeeded future if the connection could be established within the time frame configured with
+     *         {@link ClientConfigProperties#getConnectTimeout()}, a failed future otherwise.
+     */
+    Future<Void> connect(String tenantId, Vertx vertx, ClientConfigProperties clientConfig);
+
+    /**
+     * Adds an MQTT endpoint for the given tenant.
+     *
+     * @param tenantId The tenant to which the endpoint belongs.
+     * @param mqttEndpoint The endpoint to be added.
+     */
+    void addEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
+
+    /**
+     * Closes the given MQTT endpoint and if there are no other open endpoints for this tenant, it closes the
+     * corresponding AMQP connection.
+     *
+     * @param tenantId The tenant to which the endpoint belongs.
+     * @param mqttEndpoint The endpoint to be closed.
+     * @return {@code true} if the AMQP connection and all endpoints have been closed.
+     */
+    boolean closeEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
+
+    /**
+     * Closes all connections, MQTT connections as well as AMQP for all tenants.
+     */
+    void closeAllTenants();
+
+    /**
+     * Gets a client for sending telemetry data to Hono's AMQP protocol adapter.
+     *
+     * @param tenantId The tenant to which the sender belongs.
+     * @return a future with the open sender or a failed future.
+     * @see AmqpAdapterClientFactory#getOrCreateTelemetrySender()
+     */
+    Future<TelemetrySender> getOrCreateTelemetrySender(String tenantId);
+
+    /**
+     * Gets a client for sending events to Hono's AMQP protocol adapter.
+     *
+     * @param tenantId The tenant to which the sender belongs.
+     * @return a future with the open sender or a failed future.
+     * @see AmqpAdapterClientFactory#getOrCreateTelemetrySender()
+     */
+    Future<EventSender> getOrCreateEventSender(String tenantId);
+
+    /**
+     * Gets a client for sending command responses to Hono's AMQP protocol adapter.
+     *
+     * @param tenantId The tenant to which the sender belongs.
+     * @return a future with the open sender or a failed future.
+     * @see AmqpAdapterClientFactory#getOrCreateTelemetrySender()
+     */
+    Future<CommandResponder> getOrCreateCommandResponseSender(String tenantId);
+
+    /**
+     * Creates a client for consuming commands from Hono's AMQP protocol adapter for a specific device.
+     *
+     * @param tenantId The tenant to which the sender belongs.
+     * @param deviceId The device to consume commands for.
+     * @param messageHandler The handler to invoke with every command received.
+     * @return a future with the open sender or a failed future.
+     * @see AmqpAdapterClientFactory#getOrCreateTelemetrySender()
+     */
+    Future<MessageConsumer> createDeviceSpecificCommandConsumer(String tenantId, String deviceId,
+            Consumer<Message> messageHandler);
+
+    /**
+     * Creates a client for consuming commands from Hono's AMQP protocol adapter for all devices of this tenant.
+     *
+     * @param tenantId The tenant to which the sender belongs.
+     * @param messageHandler The handler to invoke with every command received.
+     * @return a future with the open sender or a failed future.
+     * @see AmqpAdapterClientFactory#getOrCreateTelemetrySender()
+     */
+    Future<MessageConsumer> createCommandConsumer(String tenantId, Consumer<Message> messageHandler);
+
+}

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
@@ -29,6 +29,9 @@ import io.vertx.mqtt.MqttEndpoint;
 
 /**
  * Manages connections for multiple tenants.
+ * <p>
+ * <b>NB</b> The {@link #connect(String, Vertx, ClientConfigProperties)} method needs to be invoked before calling any
+ * of the other methods.
  */
 public interface MultiTenantConnectionManager {
 
@@ -48,8 +51,10 @@ public interface MultiTenantConnectionManager {
      *
      * @param tenantId The tenant to which the endpoint belongs.
      * @param mqttEndpoint The endpoint to be added.
+     * @return A future indicating the outcome of the operation. The future will succeed if the endpoint has been added
+     *         successfully. Otherwise the future will fail with a failure message indicating the cause of the failure.
      */
-    void addEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
+    Future<Void> addEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
 
     /**
      * Closes the given MQTT endpoint and if there are no other open endpoints for this tenant, it closes the
@@ -57,9 +62,11 @@ public interface MultiTenantConnectionManager {
      *
      * @param tenantId The tenant to which the endpoint belongs.
      * @param mqttEndpoint The endpoint to be closed.
-     * @return {@code true} if the AMQP connection and all endpoints have been closed.
+     * @return A future indicating the outcome of the operation. The future will succeed with a boolean that is
+     *         {@code true} if the AMQP connection (and all MQTT endpoints) have been closed. If an error occurs, the
+     *         future will fail with a failure message indicating the cause of the failure.
      */
-    boolean closeEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
+    Future<Boolean> closeEndpoint(String tenantId, MqttEndpoint mqttEndpoint);
 
     /**
      * Closes all connections, MQTT connections as well as AMQP connections for all tenants.

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManager.java
@@ -36,7 +36,7 @@ import io.vertx.mqtt.MqttEndpoint;
 public interface MultiTenantConnectionManager {
 
     /**
-     * Connect to Hono's AMQP adapter with the given configuration.
+     * Connects to Hono's AMQP adapter with the given configuration.
      *
      * @param tenantId The tenant to connect.
      * @param vertx The Vert.x instance to use for the connection.

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImpl.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImpl.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.gateway.sdk.mqtt2amqp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.hono.client.MessageConsumer;
+import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
+import org.eclipse.hono.client.device.amqp.CommandResponder;
+import org.eclipse.hono.client.device.amqp.EventSender;
+import org.eclipse.hono.client.device.amqp.TelemetrySender;
+import org.eclipse.hono.config.ClientConfigProperties;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.mqtt.MqttEndpoint;
+
+/**
+ * Tracks MQTT connections per tenant and closes the AMQP connection automatically when the last MQTT connection of the
+ * tenant is closed.
+ * <p>
+ * Note: {@link #connect(String, Vertx, ClientConfigProperties)} needs to be invoked before using the instance.
+ */
+public class MultiTenantConnectionManagerImpl implements MultiTenantConnectionManager {
+
+    private final Map<String, TenantConnections> connectionsPerTenant = new HashMap<>();
+
+    @Override
+    public Future<Void> connect(final String tenantId, final Vertx vertx, final ClientConfigProperties clientConfig) {
+
+        connectionsPerTenant.computeIfAbsent(tenantId, k -> new TenantConnections(k, vertx, clientConfig).connect());
+
+        return getTenantConnections(tenantId)
+                .isConnected(clientConfig.getConnectTimeout())
+                .onFailure(ex -> {
+                    final TenantConnections failedTenant = connectionsPerTenant.remove(tenantId);
+                    if (failedTenant != null) {
+                        failedTenant.closeAllConnections();
+                    }
+                });
+    }
+
+    @Override
+    public void addEndpoint(final String tenantId, final MqttEndpoint mqttEndpoint) {
+        getTenantConnections(tenantId).addEndpoint(mqttEndpoint);
+    }
+
+    @Override
+    public boolean closeEndpoint(final String tenantId, final MqttEndpoint mqttEndpoint) {
+
+        final boolean amqpLinkClosed = getTenantConnections(tenantId).closeEndpoint(mqttEndpoint);
+        if (amqpLinkClosed) {
+            connectionsPerTenant.remove(tenantId);
+        }
+
+        return amqpLinkClosed;
+    }
+
+    @Override
+    public void closeAllTenants() {
+        connectionsPerTenant.forEach((k, connections) -> connections.closeAllConnections());
+        connectionsPerTenant.clear();
+    }
+
+    @Override
+    public Future<TelemetrySender> getOrCreateTelemetrySender(final String tenantId) {
+        try {
+            return getAmqpAdapterClientFactory(tenantId).getOrCreateTelemetrySender();
+        } catch (Exception ex) {
+            return Future.failedFuture(ex);
+        }
+    }
+
+    @Override
+    public Future<EventSender> getOrCreateEventSender(final String tenantId) {
+        try {
+            return getAmqpAdapterClientFactory(tenantId).getOrCreateEventSender();
+        } catch (Exception ex) {
+            return Future.failedFuture(ex);
+        }
+    }
+
+    @Override
+    public Future<CommandResponder> getOrCreateCommandResponseSender(final String tenantId) {
+        try {
+            return getAmqpAdapterClientFactory(tenantId).getOrCreateCommandResponseSender();
+        } catch (Exception ex) {
+            return Future.failedFuture(ex);
+        }
+    }
+
+    @Override
+    public Future<MessageConsumer> createDeviceSpecificCommandConsumer(final String tenantId, final String deviceId,
+            final Consumer<Message> messageHandler) {
+
+        try {
+            return getAmqpAdapterClientFactory(tenantId).createDeviceSpecificCommandConsumer(deviceId, messageHandler);
+        } catch (Exception ex) {
+            return Future.failedFuture(ex);
+        }
+    }
+
+    @Override
+    public Future<MessageConsumer> createCommandConsumer(final String tenantId,
+            final Consumer<Message> messageHandler) {
+
+        try {
+            return getAmqpAdapterClientFactory(tenantId).createCommandConsumer(messageHandler);
+        } catch (Exception ex) {
+            return Future.failedFuture(ex);
+        }
+    }
+
+    private TenantConnections getTenantConnections(final String tenantId) throws IllegalArgumentException {
+        final TenantConnections tenantConnections = connectionsPerTenant.get(tenantId);
+        if (tenantConnections == null) {
+            throw new IllegalArgumentException("tenant [" + tenantId + "] is not connected");
+        } else {
+            return tenantConnections;
+        }
+    }
+
+    private AmqpAdapterClientFactory getAmqpAdapterClientFactory(final String tenantId)
+            throws IllegalStateException, IllegalArgumentException {
+        return getTenantConnections(tenantId).getAmqpAdapterClientFactory();
+    }
+}

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.gateway.sdk.mqtt2amqp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.mqtt.MqttEndpoint;
+
+/**
+ * Manages all connections of one tenant, MQTT connections of devices as well as the AMQP connection to Hono's AMQP
+ * adapter.
+ * <p>
+ * Note: do not re-use an instance if it is already closed.
+ */
+class TenantConnections {
+
+    // visible for testing
+    final List<MqttEndpoint> mqttEndpoints = new ArrayList<>();
+
+    private final AmqpAdapterClientFactory amqpAdapterClientFactory;
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private boolean closed = false;
+
+    TenantConnections(final String tenantId, final Vertx vertx, final ClientConfigProperties clientConfig) {
+        this(AmqpAdapterClientFactory.create(HonoConnection.newConnection(vertx, clientConfig), tenantId));
+    }
+
+    TenantConnections(final AmqpAdapterClientFactory amqpAdapterClientFactory) {
+        this.amqpAdapterClientFactory = amqpAdapterClientFactory;
+    }
+
+    public TenantConnections connect() {
+        getAmqpAdapterClientFactory().connect().onSuccess(con -> log.debug("Connected to AMQP adapter"));
+        return this;
+    }
+
+    public void addEndpoint(final MqttEndpoint mqttEndpoint) {
+        checkNotClosed();
+        mqttEndpoints.add(mqttEndpoint);
+    }
+
+    public boolean closeEndpoint(final MqttEndpoint mqttEndpoint) {
+
+        closeEndpointIfConnected(mqttEndpoint);
+
+        mqttEndpoints.remove(mqttEndpoint);
+
+        if (mqttEndpoints.isEmpty()) {
+            closeThisInstance();
+        }
+
+        return closed;
+    }
+
+    /**
+     * Closes all MQTT endpoints and the AMQP connection.
+     */
+    public void closeAllConnections() {
+        log.info("closing all AMQP connections");
+
+        mqttEndpoints.forEach(this::closeEndpointIfConnected);
+        mqttEndpoints.clear();
+        closeThisInstance();
+    }
+
+    private void closeEndpointIfConnected(final MqttEndpoint mqttEndpoint) {
+        if (mqttEndpoint.isConnected()) {
+            log.debug("closing connection with client [client ID: {}]", mqttEndpoint.clientIdentifier());
+            mqttEndpoint.close();
+        } else {
+            log.trace("connection to client is already closed");
+        }
+    }
+
+    private void closeThisInstance() {
+        getAmqpAdapterClientFactory().disconnect();
+        closed = true;
+    }
+
+    public Future<Void> isConnected(final long connectTimeout) {
+        return getAmqpAdapterClientFactory().isConnected(connectTimeout);
+    }
+
+    public AmqpAdapterClientFactory getAmqpAdapterClientFactory() throws IllegalStateException {
+        checkNotClosed();
+        return amqpAdapterClientFactory;
+    }
+
+    private void checkNotClosed() throws IllegalStateException {
+        if (closed) {
+            throw new IllegalStateException("all connections for this tenant are already closed");
+        }
+    }
+}

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.config.ClientConfigProperties;
 import org.slf4j.Logger;
@@ -29,6 +30,10 @@ import io.vertx.mqtt.MqttEndpoint;
 /**
  * Manages all connections of one tenant, MQTT connections of devices as well as the AMQP connection to Hono's AMQP
  * adapter.
+ *
+ * By invoking {@link #connect()} an AMQP client for the tenant is connected. Each MQTT endpoint needs to be added to
+ * keep track of all MQTT connections belonging to the tenant. When the last MQTT endpoint for the tenant is closed, the
+ * AMQP client - and thus this instance - is closed automatically.
  * <p>
  * Note: do not re-use an instance if it is already closed.
  */
@@ -42,24 +47,55 @@ class TenantConnections {
 
     private boolean closed = false;
 
+    /**
+     * Creates a new instance with a new {@link AmqpAdapterClientFactory} and a new {@link HonoConnection}.
+     *
+     * @param tenantId The ID of the tenant whose connections are to be managed
+     * @param vertx The Vert.x instance to be used by the HonoConnection.
+     * @param clientConfig The client configuration to be used by the HonoConnection.
+     */
     TenantConnections(final String tenantId, final Vertx vertx, final ClientConfigProperties clientConfig) {
         this(AmqpAdapterClientFactory.create(HonoConnection.newConnection(vertx, clientConfig), tenantId));
     }
 
+    /**
+     * Creates a new instance for the given {@link AmqpAdapterClientFactory}.
+     *
+     * @param amqpAdapterClientFactory The AmqpAdapterClientFactory to use for creating AMQP clients.
+     */
     TenantConnections(final AmqpAdapterClientFactory amqpAdapterClientFactory) {
         this.amqpAdapterClientFactory = amqpAdapterClientFactory;
     }
 
+    /**
+     * Opens a connection to Hono's AMQP protocol adapter for the tenant to be managed.
+     *
+     * @return This instance for fluent use.
+     * @throws IllegalStateException if this instance is already closed.
+     */
     public TenantConnections connect() {
         getAmqpAdapterClientFactory().connect().onSuccess(con -> log.debug("Connected to AMQP adapter"));
         return this;
     }
 
+    /**
+     * Adds an MQTT endpoint for the tenant.
+     *
+     * @param mqttEndpoint The endpoint to add.
+     */
     public void addEndpoint(final MqttEndpoint mqttEndpoint) {
         checkNotClosed();
         mqttEndpoints.add(mqttEndpoint);
     }
 
+    /**
+     * Closes the given MQTT endpoint and if there are no other MQTT endpoints present, it closes the AMQP client and
+     * this instance.
+     *
+     * @param mqttEndpoint The endpoint to be closed.
+     * @return {@code true} if the AMQP connection has been closed.
+     * @throws IllegalStateException if this instance is already closed.
+     */
     public boolean closeEndpoint(final MqttEndpoint mqttEndpoint) {
 
         closeEndpointIfConnected(mqttEndpoint);
@@ -75,6 +111,8 @@ class TenantConnections {
 
     /**
      * Closes all MQTT endpoints and the AMQP connection.
+     *
+     * @throws IllegalStateException if this instance is already closed.
      */
     public void closeAllConnections() {
         log.info("closing all AMQP connections");
@@ -98,10 +136,24 @@ class TenantConnections {
         closed = true;
     }
 
+    /**
+     * Checks whether the AMQP connection is currently established.
+     *
+     * @param connectTimeout The maximum number of milliseconds to wait for an ongoing connection attempt to finish.
+     * @return A succeeded future if this connection is established. Otherwise, the future will be failed with a
+     *         {@link ServerErrorException}.
+     * @throws IllegalStateException if this instance is already closed.
+     */
     public Future<Void> isConnected(final long connectTimeout) {
         return getAmqpAdapterClientFactory().isConnected(connectTimeout);
     }
 
+    /**
+     * Returns the AmqpAdapterClientFactory for the tenant.
+     *
+     * @return The AmqpAdapterClientFactory.
+     * @throws IllegalStateException if this instance is already closed.
+     */
     public AmqpAdapterClientFactory getAmqpAdapterClientFactory() throws IllegalStateException {
         checkNotClosed();
         return amqpAdapterClientFactory;

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/main/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnections.java
@@ -111,8 +111,6 @@ class TenantConnections {
 
     /**
      * Closes all MQTT endpoints and the AMQP connection.
-     *
-     * @throws IllegalStateException if this instance is already closed.
      */
     public void closeAllConnections() {
         log.info("closing all AMQP connections");
@@ -132,7 +130,7 @@ class TenantConnections {
     }
 
     private void closeThisInstance() {
-        getAmqpAdapterClientFactory().disconnect();
+        amqpAdapterClientFactory.disconnect();
         closed = true;
     }
 

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGatewayTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGatewayTest.java
@@ -14,8 +14,6 @@
 package org.eclipse.hono.gateway.sdk.mqtt2amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.hono.gateway.sdk.mqtt2amqp.TestMqttProtocolGateway.GW_PASSWORD;
-import static org.eclipse.hono.gateway.sdk.mqtt2amqp.TestMqttProtocolGateway.GW_USERNAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -465,7 +463,7 @@ public class AbstractMqttProtocolGatewayTest {
         // WHEN the gateway connects
         connectTestDevice(gateway);
 
-        ArgumentCaptor<ClientConfigProperties> configPropertiesArgumentCaptor = ArgumentCaptor
+        final ArgumentCaptor<ClientConfigProperties> configPropertiesArgumentCaptor = ArgumentCaptor
                 .forClass(ClientConfigProperties.class);
 
         verify(tenantConnectionManager).connect(anyString(), any(), configPropertiesArgumentCaptor.capture());
@@ -473,8 +471,8 @@ public class AbstractMqttProtocolGatewayTest {
         final ClientConfigProperties clientConfig = configPropertiesArgumentCaptor.getValue();
 
         // THEN the AMQP connection is authenticated with the provided credentials...
-        assertThat(clientConfig.getUsername()).isEqualTo(GW_USERNAME);
-        assertThat(clientConfig.getPassword()).isEqualTo(GW_PASSWORD);
+        assertThat(clientConfig.getUsername()).isEqualTo(TestMqttProtocolGateway.GW_USERNAME);
+        assertThat(clientConfig.getPassword()).isEqualTo(TestMqttProtocolGateway.GW_PASSWORD);
 
         // ... and not with the credentials from the configuration
         assertThat(clientConfig.getUsername()).isNotEqualTo(configWithoutCredentials.getUsername());
@@ -503,7 +501,7 @@ public class AbstractMqttProtocolGatewayTest {
         // WHEN the gateway connects
         connectTestDevice(gateway);
 
-        ArgumentCaptor<ClientConfigProperties> configPropertiesArgumentCaptor = ArgumentCaptor
+        final ArgumentCaptor<ClientConfigProperties> configPropertiesArgumentCaptor = ArgumentCaptor
                 .forClass(ClientConfigProperties.class);
 
         verify(tenantConnectionManager).connect(anyString(), any(), configPropertiesArgumentCaptor.capture());
@@ -515,8 +513,8 @@ public class AbstractMqttProtocolGatewayTest {
         assertThat(clientConfig.getPassword()).isEqualTo(password);
 
         // ... and not with the credentials from the implementation
-        assertThat(clientConfig.getUsername()).isNotEqualTo(GW_USERNAME);
-        assertThat(clientConfig.getPassword()).isNotEqualTo(GW_PASSWORD);
+        assertThat(clientConfig.getUsername()).isNotEqualTo(TestMqttProtocolGateway.GW_USERNAME);
+        assertThat(clientConfig.getPassword()).isNotEqualTo(TestMqttProtocolGateway.GW_PASSWORD);
     }
 
     /**
@@ -611,7 +609,7 @@ public class AbstractMqttProtocolGatewayTest {
 
         verify(protonSender).send(any(), handlerArgumentCaptor.capture());
 
-        ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
+        final ProtonDelivery protonDelivery = mock(ProtonDelivery.class);
         when(protonDelivery.getRemoteState()).thenReturn(new Rejected());
         when(protonDelivery.remotelySettled()).thenReturn(true);
 

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGatewayTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/AbstractMqttProtocolGatewayTest.java
@@ -109,7 +109,8 @@ public class AbstractMqttProtocolGatewayTest {
 
         tenantConnectionManager = mock(MultiTenantConnectionManager.class);
         when(tenantConnectionManager.connect(anyString(), any(), any())).thenReturn(Future.succeededFuture());
-        when(tenantConnectionManager.closeEndpoint(anyString(), any())).thenReturn(true);
+        when(tenantConnectionManager.addEndpoint(anyString(), any())).thenReturn(Future.succeededFuture());
+        when(tenantConnectionManager.closeEndpoint(anyString(), any())).thenReturn(Future.succeededFuture(true));
 
         amqpClientConfig = new ClientConfigProperties();
         final HonoConnection connection = mockHonoConnection(vertx, amqpClientConfig, protonSender);

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +56,7 @@ public class MultiTenantConnectionManagerImplTest {
         connectionManager.connect(TENANT_ID, vertx, new ClientConfigProperties());
         connectionManager.addEndpoint(TENANT_ID, endpoint);
 
-        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint)).isTrue();
+        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint).result()).isTrue();
 
     }
 
@@ -71,7 +70,7 @@ public class MultiTenantConnectionManagerImplTest {
         connectionManager.addEndpoint(TENANT_ID, endpoint);
         connectionManager.addEndpoint(TENANT_ID, mock(MqttEndpoint.class));
 
-        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint)).isFalse();
+        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint).result()).isFalse();
 
     }
 
@@ -85,26 +84,23 @@ public class MultiTenantConnectionManagerImplTest {
 
         connectionManager.closeAllTenants();
 
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> connectionManager.addEndpoint(TENANT_ID, endpoint));
+        assertThat(connectionManager.addEndpoint(TENANT_ID, endpoint).failed()).isTrue();
     }
 
     /**
-     * Verifies that trying to add an endpoint without connecting the tenant first, throws an exception.
+     * Verifies that trying to add an endpoint without connecting the tenant first fails.
      */
     @Test
     public void addEndpointFailsIfNotConnected() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> connectionManager.addEndpoint(TENANT_ID, endpoint));
+        assertThat(connectionManager.addEndpoint(TENANT_ID, endpoint).failed()).isTrue();
     }
 
     /**
-     * Verifies that trying to close an endpoint without connecting the tenant first, throws an exception.
+     * Verifies that trying to close an endpoint without connecting the tenant first fails.
      */
     @Test
     public void closeEndpointFailsIfNotConnected() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-                () -> connectionManager.closeEndpoint(TENANT_ID, endpoint));
+        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint).failed()).isTrue();
     }
 
     /**
@@ -114,20 +110,17 @@ public class MultiTenantConnectionManagerImplTest {
     @Test
     public void futureFailsIfNotConnected() {
 
-        assertThat(connectionManager.getOrCreateTelemetrySender(TENANT_ID).cause())
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(connectionManager.getOrCreateTelemetrySender(TENANT_ID).failed()).isTrue();
 
-        assertThat(connectionManager.getOrCreateEventSender(TENANT_ID).cause())
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(connectionManager.getOrCreateEventSender(TENANT_ID).failed()).isTrue();
 
-        assertThat(connectionManager.getOrCreateCommandResponseSender(TENANT_ID).cause())
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(connectionManager.getOrCreateCommandResponseSender(TENANT_ID).failed()).isTrue();
 
         assertThat(connectionManager.createDeviceSpecificCommandConsumer(TENANT_ID, "device-id", msg -> {
-        }).cause()).isInstanceOf(IllegalArgumentException.class);
+        }).failed()).isTrue();
 
         assertThat(connectionManager.createCommandConsumer(TENANT_ID, msg -> {
-        }).cause()).isInstanceOf(IllegalArgumentException.class);
+        }).failed()).isTrue();
 
     }
 

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package org.eclipse.hono.gateway.sdk.mqtt2amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/MultiTenantConnectionManagerImplTest.java
@@ -1,0 +1,121 @@
+package org.eclipse.hono.gateway.sdk.mqtt2amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hono.config.ClientConfigProperties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.mqtt.MqttEndpoint;
+
+/**
+ * Verifies behavior of {@link MultiTenantConnectionManagerImpl}.
+ */
+public class MultiTenantConnectionManagerImplTest {
+
+    private static final String TENANT_ID = "test-tenant";
+    private MultiTenantConnectionManagerImpl connectionManager;
+    private MqttEndpoint endpoint;
+    private Vertx vertx;
+
+    /**
+     * Sets up common fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        connectionManager = new MultiTenantConnectionManagerImpl();
+        endpoint = mock(MqttEndpoint.class);
+
+        vertx = mock(Vertx.class);
+        when(vertx.getOrCreateContext()).thenReturn(mock(Context.class));
+    }
+
+    /**
+     * Verifies that closing the last endpoint of the tenant, closes the AMQP connection.
+     */
+    @Test
+    public void amqpConnectionIsClosedWhenClosingLastEndpoint() {
+
+        connectionManager.connect(TENANT_ID, vertx, new ClientConfigProperties());
+        connectionManager.addEndpoint(TENANT_ID, endpoint);
+
+        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint)).isTrue();
+
+    }
+
+    /**
+     * Verifies that closing an endpoint while there are others for the same tenant, the AMQP connection is not closed.
+     */
+    @Test
+    public void amqpConnectionIsOpenWhenClosingEndpointThatIsNotTheLastOne() {
+
+        connectionManager.connect(TENANT_ID, vertx, new ClientConfigProperties());
+        connectionManager.addEndpoint(TENANT_ID, endpoint);
+        connectionManager.addEndpoint(TENANT_ID, mock(MqttEndpoint.class));
+
+        assertThat(connectionManager.closeEndpoint(TENANT_ID, endpoint)).isFalse();
+
+    }
+
+    /**
+     * Verifies that all tenants are closed when closeAllTenants() is invoked.
+     */
+    @Test
+    public void addEndpointFailsIfInstanceIsClosed() {
+
+        connectionManager.connect(TENANT_ID, vertx, new ClientConfigProperties());
+
+        connectionManager.closeAllTenants();
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> connectionManager.addEndpoint(TENANT_ID, endpoint));
+    }
+
+    /**
+     * Verifies that trying to add an endpoint without connecting the tenant first, throws an exception.
+     */
+    @Test
+    public void addEndpointFailsIfNotConnected() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> connectionManager.addEndpoint(TENANT_ID, endpoint));
+    }
+
+    /**
+     * Verifies that trying to close an endpoint without connecting the tenant first, throws an exception.
+     */
+    @Test
+    public void closeEndpointFailsIfNotConnected() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> connectionManager.closeEndpoint(TENANT_ID, endpoint));
+    }
+
+    /**
+     * Verifies that calling one of the methods that delegate to AmqpAdapterClientFactory fails if the tenant is not
+     * connected.
+     */
+    @Test
+    public void futureFailsIfNotConnected() {
+
+        assertThat(connectionManager.getOrCreateTelemetrySender(TENANT_ID).cause())
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(connectionManager.getOrCreateEventSender(TENANT_ID).cause())
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(connectionManager.getOrCreateCommandResponseSender(TENANT_ID).cause())
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(connectionManager.createDeviceSpecificCommandConsumer(TENANT_ID, "device-id", msg -> {
+        }).cause()).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(connectionManager.createCommandConsumer(TENANT_ID, msg -> {
+        }).cause()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+}

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnectionsTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnectionsTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
 package org.eclipse.hono.gateway.sdk.mqtt2amqp;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnectionsTest.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TenantConnectionsTest.java
@@ -1,0 +1,118 @@
+package org.eclipse.hono.gateway.sdk.mqtt2amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.hono.client.HonoConnection;
+import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.Future;
+import io.vertx.mqtt.MqttEndpoint;
+
+/**
+ * Verifies behavior of {@link TenantConnections}.
+ */
+public class TenantConnectionsTest {
+
+    private TenantConnections tenantConnections;
+    private MqttEndpoint endpoint;
+    private AmqpAdapterClientFactory amqpAdapterClientFactory;
+
+    /**
+     * Sets up common fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        amqpAdapterClientFactory = mock(AmqpAdapterClientFactory.class);
+
+        tenantConnections = new TenantConnections(amqpAdapterClientFactory);
+        endpoint = mock(MqttEndpoint.class);
+    }
+
+    /**
+     * Verifies that the connect method returns the instance.
+     */
+    @Test
+    public void connectReturnsTheInstance() {
+        when(amqpAdapterClientFactory.connect()).thenReturn(Future.succeededFuture(mock(HonoConnection.class)));
+
+        assertThat(tenantConnections.connect()).isEqualTo(tenantConnections);
+    }
+
+    /**
+     * Verifies that adding an endpoint works.
+     */
+    @Test
+    public void containsEndpointWhenAdding() {
+        tenantConnections.addEndpoint(endpoint);
+
+        assertThat(tenantConnections.mqttEndpoints.size()).isEqualTo(1);
+        assertThat(tenantConnections.mqttEndpoints.contains(endpoint)).isTrue();
+    }
+
+    /**
+     * Verifies that removing an endpoint works.
+     */
+    @Test
+    public void endpointIsRemovedWhenClosingEndpoint() {
+        tenantConnections.addEndpoint(endpoint);
+
+        tenantConnections.closeEndpoint(endpoint);
+
+        assertThat(tenantConnections.mqttEndpoints.isEmpty()).isTrue();
+    }
+
+    /**
+     * Verifies that the instance is closed when the last endpoint is closed.
+     */
+    @Test
+    public void instanceIsClosedWhenClosingLastEndpoint() {
+        tenantConnections.addEndpoint(endpoint);
+
+        tenantConnections.closeEndpoint(endpoint);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> tenantConnections.getAmqpAdapterClientFactory());
+    }
+
+    /**
+     * Verifies that the instance is NOT closed when an endpoint is closed while other endpoints are still open.
+     */
+    @Test
+    public void instanceIsOpenWhenClosingEndpointThatIsNotTheLastOne() {
+        tenantConnections.addEndpoint(endpoint);
+        tenantConnections.addEndpoint(mock(MqttEndpoint.class));
+
+        tenantConnections.closeEndpoint(endpoint);
+
+        assertThat(tenantConnections.getAmqpAdapterClientFactory()).isNotNull();
+    }
+
+    /**
+     * Verifies that the instance is closed when closeAllConnections() is invoked.
+     */
+    @Test
+    public void instanceIsClosedWhenInvokingClose() {
+
+        tenantConnections.getAmqpAdapterClientFactory();
+
+        tenantConnections.closeAllConnections();
+
+        Assertions.assertThrows(IllegalStateException.class, () -> tenantConnections.getAmqpAdapterClientFactory());
+    }
+
+    /**
+     * Verifies that the isConnected() method delegates the check to the client factory.
+     */
+    @Test
+    public void isConnectedDelegatesToClientFactory() {
+        tenantConnections.isConnected(5L);
+        verify(amqpAdapterClientFactory).isConnected(eq(5L));
+    }
+
+}

--- a/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TestMqttProtocolGateway.java
+++ b/protocol-gateway/mqtt-protocol-gateway-template/src/test/java/org/eclipse/hono/gateway/sdk/mqtt2amqp/TestMqttProtocolGateway.java
@@ -17,14 +17,7 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.hono.auth.Device;
-import org.eclipse.hono.client.device.amqp.AmqpAdapterClientFactory;
 import org.eclipse.hono.config.ClientConfigProperties;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.Command;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.CommandSubscriptionsManager;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.Credentials;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.MqttCommandContext;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.MqttDownstreamContext;
-import org.eclipse.hono.gateway.sdk.mqtt2amqp.MqttProtocolGatewayConfig;
 import org.eclipse.hono.gateway.sdk.mqtt2amqp.downstream.DownstreamMessage;
 import org.eclipse.hono.gateway.sdk.mqtt2amqp.downstream.EventMessage;
 
@@ -66,15 +59,15 @@ class TestMqttProtocolGateway extends AbstractMqttProtocolGateway {
     private final AtomicBoolean startupComplete = new AtomicBoolean();
     private final AtomicBoolean shutdownStarted = new AtomicBoolean();
     private final AtomicBoolean connectionClosed = new AtomicBoolean();
-    private final AmqpAdapterClientFactory amqpAdapterClientFactory;
 
     private CommandSubscriptionsManager commandSubscriptionsManager;
 
     TestMqttProtocolGateway(final ClientConfigProperties clientConfigProperties,
-            final MqttProtocolGatewayConfig mqttProtocolGatewayConfig, final Vertx vertx,
-            final AmqpAdapterClientFactory amqpAdapterClientFactory) {
-        super(clientConfigProperties, mqttProtocolGatewayConfig);
-        this.amqpAdapterClientFactory = amqpAdapterClientFactory;
+            final MqttProtocolGatewayConfig mqttProtocolGatewayConfig,
+            final Vertx vertx,
+            final MultiTenantConnectionManager tenantConnectionManager) {
+
+        super(clientConfigProperties, mqttProtocolGatewayConfig, tenantConnectionManager);
         super.vertx = vertx;
     }
 
@@ -113,12 +106,6 @@ class TestMqttProtocolGateway extends AbstractMqttProtocolGateway {
      */
     public CommandSubscriptionsManager getCommandSubscriptionsManager() {
         return commandSubscriptionsManager;
-    }
-
-    @Override
-    AmqpAdapterClientFactory createTenantClientFactory(final String tenantId,
-            final ClientConfigProperties clientConfig) {
-        return amqpAdapterClientFactory;
     }
 
     @Override


### PR DESCRIPTION
The MQTT endpoints are tracked for each tenant. When the last endpoint of a tenant is
closed, the AMQP connection for this tenant is closed as well.